### PR TITLE
Upgrade ratatui 0.28 -> 0.30 to fix lru vulnerability

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -86,7 +86,8 @@ Use `checked_duration_since` for all `Instant` arithmetic to avoid panics.
 - Commands handle their own error display via `CommandOutput`
 
 ### Dependencies
-- Pin to major version: `anyhow = "1"`, `ratatui = "0.28"`, `crossterm = "0.27"`
+- Pin to major version: `anyhow = "1"`, `ratatui = "0.30"`, `crossterm = "0.29"`
+- Shared deps (`ratatui`, `crossterm`) are centralized in `[workspace.dependencies]`; crates reference them via `{ workspace = true }`
 - Internal workspace crates use path dependencies: `{ path = "../crate-name" }`
 - Logging via `tracing` crate (`tracing::info!`, `tracing::warn!`, etc.)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,16 +24,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
-name = "cassowary"
-version = "0.3.0"
+name = "block-buffer"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "castaway"
@@ -51,10 +108,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "compact_str"
-version = "0.8.1"
+name = "cfg_aliases"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -62,6 +125,24 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -81,29 +162,15 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "crossterm_winapi",
- "libc",
- "mio 0.8.11",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "mio 1.1.1",
+ "derive_more",
+ "document-features",
+ "mio",
  "parking_lot",
  "rustix",
  "signal-hook",
@@ -118,6 +185,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
 ]
 
 [[package]]
@@ -140,7 +227,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -151,8 +238,14 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "deranged"
@@ -161,6 +254,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -182,6 +307,15 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -207,10 +341,68 @@ dependencies = [
 ]
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
+name = "euclid"
+version = "0.22.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -224,10 +416,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.15.5"
+name = "getrandom"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -239,6 +443,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ident_case"
@@ -265,14 +475,14 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -282,6 +492,33 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "kasuari"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
+dependencies = [
+ "hashbrown",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lazy_static"
@@ -301,15 +538,30 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
+name = "line-clipping"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -328,11 +580,21 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
  "hashbrown",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
 ]
 
 [[package]]
@@ -351,16 +613,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "mio"
-version = "0.8.11"
+name = "memmem"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
+ "autocfg",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -372,6 +643,29 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -390,6 +684,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +723,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "parking_lot"
@@ -425,16 +757,111 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pest"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "powerfmt"
@@ -461,23 +888,108 @@ dependencies = [
 ]
 
 [[package]]
-name = "ratatui"
-version = "0.28.1"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "bitflags",
- "cassowary",
- "compact_str",
- "crossterm 0.28.1",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
  "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.10.0",
+ "compact_str",
+ "hashbrown",
+ "indoc",
  "itertools",
+ "kasuari",
  "lru",
- "paste",
  "strum",
- "strum_macros",
+ "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "strum",
+ "time",
+ "unicode-segmentation",
  "unicode-width",
 ]
 
@@ -487,7 +999,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -496,9 +1008,21 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -519,16 +1043,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
-name = "rustix"
-version = "0.38.44"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "bitflags",
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -550,12 +1083,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -575,7 +1115,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -589,6 +1129,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -617,8 +1168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 0.8.11",
- "mio 1.1.1",
+ "mio",
  "signal-hook",
 ]
 
@@ -631,6 +1181,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "smallvec"
@@ -647,7 +1203,7 @@ name = "spud-app"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "crossterm 0.27.0",
+ "crossterm",
  "ratatui",
  "spud-core",
  "spud-mod-hello",
@@ -665,7 +1221,7 @@ name = "spud-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "crossterm 0.27.0",
+ "crossterm",
  "dirs",
  "tracing",
  "tracing-appender",
@@ -716,24 +1272,34 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -745,6 +1311,69 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.10.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
 ]
 
 [[package]]
@@ -773,7 +1402,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -784,7 +1413,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -804,7 +1433,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -858,7 +1489,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -914,6 +1545,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,9 +1570,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
@@ -938,9 +1581,27 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+dependencies = [
+ "atomic",
+ "getrandom 0.3.4",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -949,10 +1610,151 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
+]
 
 [[package]]
 name = "winapi"
@@ -988,16 +1790,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1015,29 +1808,13 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1047,22 +1824,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1071,28 +1836,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1101,22 +1848,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1125,10 +1860,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ members = [
   "crates/spud-mod-hello",
   "crates/spud-mod-stats",
 ]
+
+[workspace.dependencies]
+crossterm = "0.29"
+ratatui = "0.30"

--- a/crates/spud-app/Cargo.toml
+++ b/crates/spud-app/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-crossterm = "0.27"
-ratatui = "0.28"
+crossterm = { workspace = true }
+ratatui = { workspace = true }
 tracing = "0.1"
 
 spud-core = { path = "../spud-core" }

--- a/crates/spud-core/Cargo.toml
+++ b/crates/spud-core/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-crossterm = "0.27"
+crossterm = { workspace = true }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-appender = "0.2"

--- a/crates/spud-core/src/bus.rs
+++ b/crates/spud-core/src/bus.rs
@@ -50,7 +50,9 @@ mod tests {
     #[test]
     fn publish_enqueues_events() {
         let mut bus = EventBus::new();
-        bus.publish(Event::Tick { now: Instant::now() });
+        bus.publish(Event::Tick {
+            now: Instant::now(),
+        });
         bus.publish(Event::Quit);
         assert!(bus.has_pending());
     }
@@ -58,7 +60,9 @@ mod tests {
     #[test]
     fn drain_returns_all_and_empties() {
         let mut bus = EventBus::new();
-        bus.publish(Event::Tick { now: Instant::now() });
+        bus.publish(Event::Tick {
+            now: Instant::now(),
+        });
         bus.publish(Event::Quit);
         let events = bus.drain();
         assert_eq!(events.len(), 2);

--- a/crates/spud-core/src/command.rs
+++ b/crates/spud-core/src/command.rs
@@ -39,11 +39,15 @@ pub trait Command: Send + Sync {
     /// The primary name used to invoke this command (e.g. `"help"`).
     fn name(&self) -> &str;
     /// Alternative names that also invoke this command (e.g. `["?"]`).
-    fn aliases(&self) -> &[&str] { &[] }
+    fn aliases(&self) -> &[&str] {
+        &[]
+    }
     /// A one-line description shown in the help listing.
     fn description(&self) -> &str;
     /// Usage string shown in help detail (e.g. `"switch <module_id>"`).
-    fn usage(&self) -> &str { self.name() }
+    fn usage(&self) -> &str {
+        self.name()
+    }
     /// Execute the command with the given arguments and context.
     fn execute(&self, args: &[&str], ctx: &mut CommandContext) -> CommandOutput;
 }
@@ -93,9 +97,10 @@ impl CommandRegistry {
 
         match self.lookup.get(name) {
             Some(&idx) => self.commands[idx].execute(args, ctx),
-            None => CommandOutput::Lines(vec![
-                format!("unknown command: '{}'. Type 'help' for available commands.", name),
-            ]),
+            None => CommandOutput::Lines(vec![format!(
+                "unknown command: '{}'. Type 'help' for available commands.",
+                name
+            )]),
         }
     }
 
@@ -111,16 +116,25 @@ impl CommandRegistry {
 pub struct HelpCommand;
 
 impl Command for HelpCommand {
-    fn name(&self) -> &str { "help" }
-    fn aliases(&self) -> &[&str] { &["?"] }
-    fn description(&self) -> &str { "List commands or show specific help" }
-    fn usage(&self) -> &str { "help [command]" }
+    fn name(&self) -> &str {
+        "help"
+    }
+    fn aliases(&self) -> &[&str] {
+        &["?"]
+    }
+    fn description(&self) -> &str {
+        "List commands or show specific help"
+    }
+    fn usage(&self) -> &str {
+        "help [command]"
+    }
 
     fn execute(&self, args: &[&str], _ctx: &mut CommandContext) -> CommandOutput {
         if !args.is_empty() {
-            return CommandOutput::Lines(vec![
-                format!("help for '{}' — use 'help' to list all commands", args[0]),
-            ]);
+            return CommandOutput::Lines(vec![format!(
+                "help for '{}' — use 'help' to list all commands",
+                args[0]
+            )]);
         }
         CommandOutput::Lines(vec!["Type 'help' to list all commands.".into()])
     }
@@ -130,9 +144,15 @@ impl Command for HelpCommand {
 pub struct ClearCommand;
 
 impl Command for ClearCommand {
-    fn name(&self) -> &str { "clear" }
-    fn aliases(&self) -> &[&str] { &["cls"] }
-    fn description(&self) -> &str { "Clear console log" }
+    fn name(&self) -> &str {
+        "clear"
+    }
+    fn aliases(&self) -> &[&str] {
+        &["cls"]
+    }
+    fn description(&self) -> &str {
+        "Clear console log"
+    }
 
     fn execute(&self, _args: &[&str], ctx: &mut CommandContext) -> CommandOutput {
         ctx.console.clear_logs();
@@ -144,16 +164,31 @@ impl Command for ClearCommand {
 pub struct ModulesCommand;
 
 impl Command for ModulesCommand {
-    fn name(&self) -> &str { "modules" }
-    fn aliases(&self) -> &[&str] { &["mods"] }
-    fn description(&self) -> &str { "List registered modules" }
+    fn name(&self) -> &str {
+        "modules"
+    }
+    fn aliases(&self) -> &[&str] {
+        &["mods"]
+    }
+    fn description(&self) -> &str {
+        "List registered modules"
+    }
 
     fn execute(&self, _args: &[&str], ctx: &mut CommandContext) -> CommandOutput {
         let active_id = ctx.registry.active_id().map(|s| s.to_string());
-        let lines: Vec<String> = ctx.registry.list().iter().map(|(id, title)| {
-            let marker = if Some(id.to_string()) == active_id { " *" } else { "" };
-            format!("  {} — {}{}", id, title, marker)
-        }).collect();
+        let lines: Vec<String> = ctx
+            .registry
+            .list()
+            .iter()
+            .map(|(id, title)| {
+                let marker = if Some(id.to_string()) == active_id {
+                    " *"
+                } else {
+                    ""
+                };
+                format!("  {} — {}{}", id, title, marker)
+            })
+            .collect();
         CommandOutput::Lines(lines)
     }
 }
@@ -162,10 +197,18 @@ impl Command for ModulesCommand {
 pub struct SwitchCommand;
 
 impl Command for SwitchCommand {
-    fn name(&self) -> &str { "switch" }
-    fn aliases(&self) -> &[&str] { &["sw"] }
-    fn description(&self) -> &str { "Switch active module" }
-    fn usage(&self) -> &str { "switch <module_id>" }
+    fn name(&self) -> &str {
+        "switch"
+    }
+    fn aliases(&self) -> &[&str] {
+        &["sw"]
+    }
+    fn description(&self) -> &str {
+        "Switch active module"
+    }
+    fn usage(&self) -> &str {
+        "switch <module_id>"
+    }
 
     fn execute(&self, args: &[&str], ctx: &mut CommandContext) -> CommandOutput {
         if args.is_empty() {
@@ -188,9 +231,15 @@ impl Command for SwitchCommand {
 pub struct QuitCommand;
 
 impl Command for QuitCommand {
-    fn name(&self) -> &str { "quit" }
-    fn aliases(&self) -> &[&str] { &["exit", "q"] }
-    fn description(&self) -> &str { "Exit SPUD" }
+    fn name(&self) -> &str {
+        "quit"
+    }
+    fn aliases(&self) -> &[&str] {
+        &["exit", "q"]
+    }
+    fn description(&self) -> &str {
+        "Exit SPUD"
+    }
 
     fn execute(&self, _args: &[&str], _ctx: &mut CommandContext) -> CommandOutput {
         CommandOutput::Quit
@@ -201,9 +250,15 @@ impl Command for QuitCommand {
 pub struct UptimeCommand;
 
 impl Command for UptimeCommand {
-    fn name(&self) -> &str { "uptime" }
-    fn aliases(&self) -> &[&str] { &[] }
-    fn description(&self) -> &str { "Show runtime uptime" }
+    fn name(&self) -> &str {
+        "uptime"
+    }
+    fn aliases(&self) -> &[&str] {
+        &[]
+    }
+    fn description(&self) -> &str {
+        "Show runtime uptime"
+    }
 
     fn execute(&self, _args: &[&str], ctx: &mut CommandContext) -> CommandOutput {
         let elapsed = ctx.started_at.elapsed();
@@ -219,9 +274,15 @@ impl Command for UptimeCommand {
 pub struct TpsCommand;
 
 impl Command for TpsCommand {
-    fn name(&self) -> &str { "tps" }
-    fn aliases(&self) -> &[&str] { &["fps"] }
-    fn description(&self) -> &str { "Show ticks-per-second" }
+    fn name(&self) -> &str {
+        "tps"
+    }
+    fn aliases(&self) -> &[&str] {
+        &["fps"]
+    }
+    fn description(&self) -> &str {
+        "Show ticks-per-second"
+    }
 
     fn execute(&self, _args: &[&str], ctx: &mut CommandContext) -> CommandOutput {
         CommandOutput::Lines(vec![format!("TPS: {:.1}", ctx.tick_counter.tps())])
@@ -232,10 +293,18 @@ impl Command for TpsCommand {
 pub struct EchoCommand;
 
 impl Command for EchoCommand {
-    fn name(&self) -> &str { "echo" }
-    fn aliases(&self) -> &[&str] { &[] }
-    fn description(&self) -> &str { "Print message to console" }
-    fn usage(&self) -> &str { "echo <message>" }
+    fn name(&self) -> &str {
+        "echo"
+    }
+    fn aliases(&self) -> &[&str] {
+        &[]
+    }
+    fn description(&self) -> &str {
+        "Print message to console"
+    }
+    fn usage(&self) -> &str {
+        "echo <message>"
+    }
 
     fn execute(&self, args: &[&str], _ctx: &mut CommandContext) -> CommandOutput {
         CommandOutput::Lines(vec![args.join(" ")])
@@ -274,19 +343,41 @@ mod tests {
         title: &'static str,
     }
     impl Module for FakeModule {
-        fn id(&self) -> &'static str { self.id }
-        fn title(&self) -> &'static str { self.title }
-        fn as_any(&self) -> &dyn std::any::Any { self }
+        fn id(&self) -> &'static str {
+            self.id
+        }
+        fn title(&self) -> &'static str {
+            self.title
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
     }
 
     fn make_ctx() -> (ModuleRegistry, Console, EventBus, TickCounter, Instant) {
         let mut reg = ModuleRegistry::new();
-        reg.register(Box::new(FakeModule { id: "hello", title: "Hello" })).unwrap();
-        reg.register(Box::new(FakeModule { id: "stats", title: "Stats" })).unwrap();
-        (reg, Console::default(), EventBus::new(), TickCounter::default(), Instant::now())
+        reg.register(Box::new(FakeModule {
+            id: "hello",
+            title: "Hello",
+        }))
+        .unwrap();
+        reg.register(Box::new(FakeModule {
+            id: "stats",
+            title: "Stats",
+        }))
+        .unwrap();
+        (
+            reg,
+            Console::default(),
+            EventBus::new(),
+            TickCounter::default(),
+            Instant::now(),
+        )
     }
 
-    fn ctx_from(parts: &mut (ModuleRegistry, Console, EventBus, TickCounter, Instant)) -> CommandContext<'_> {
+    fn ctx_from(
+        parts: &mut (ModuleRegistry, Console, EventBus, TickCounter, Instant),
+    ) -> CommandContext<'_> {
         CommandContext {
             registry: &mut parts.0,
             console: &mut parts.1,

--- a/crates/spud-core/src/console.rs
+++ b/crates/spud-core/src/console.rs
@@ -69,8 +69,11 @@ impl Console {
                 // Closing started_at so its fraction equals the same position.
                 // Closing fraction = 1.0 - close_progress, so we need
                 // close_progress = 1.0 - open_fraction.
-                let elapsed = now.checked_duration_since(started_at).unwrap_or(Duration::ZERO);
-                let open_fraction = (elapsed.as_secs_f64() / self.slide_duration.as_secs_f64()).min(1.0);
+                let elapsed = now
+                    .checked_duration_since(started_at)
+                    .unwrap_or(Duration::ZERO);
+                let open_fraction =
+                    (elapsed.as_secs_f64() / self.slide_duration.as_secs_f64()).min(1.0);
                 let elapsed_closing = self.slide_duration.mul_f64(1.0 - open_fraction);
                 SlideState::Closing {
                     started_at: now - elapsed_closing,
@@ -81,8 +84,11 @@ impl Console {
                 // Opening started_at so its fraction equals the same position.
                 // Opening fraction = open_progress, and current fraction =
                 // 1.0 - close_progress, so open_progress = 1.0 - close_progress.
-                let elapsed = now.checked_duration_since(started_at).unwrap_or(Duration::ZERO);
-                let close_progress = (elapsed.as_secs_f64() / self.slide_duration.as_secs_f64()).min(1.0);
+                let elapsed = now
+                    .checked_duration_since(started_at)
+                    .unwrap_or(Duration::ZERO);
+                let close_progress =
+                    (elapsed.as_secs_f64() / self.slide_duration.as_secs_f64()).min(1.0);
                 let elapsed_opening = self.slide_duration.mul_f64(1.0 - close_progress);
                 SlideState::Opening {
                     started_at: now - elapsed_opening,
@@ -95,14 +101,22 @@ impl Console {
     pub fn update(&mut self, now: Instant) {
         self.slide = match self.slide {
             SlideState::Opening { started_at } => {
-                if now.checked_duration_since(started_at).unwrap_or(Duration::ZERO) >= self.slide_duration {
+                if now
+                    .checked_duration_since(started_at)
+                    .unwrap_or(Duration::ZERO)
+                    >= self.slide_duration
+                {
                     SlideState::Open
                 } else {
                     self.slide
                 }
             }
             SlideState::Closing { started_at } => {
-                if now.checked_duration_since(started_at).unwrap_or(Duration::ZERO) >= self.slide_duration {
+                if now
+                    .checked_duration_since(started_at)
+                    .unwrap_or(Duration::ZERO)
+                    >= self.slide_duration
+                {
                     SlideState::Hidden
                 } else {
                     self.slide
@@ -118,11 +132,15 @@ impl Console {
             SlideState::Hidden => 0.0,
             SlideState::Open => 1.0,
             SlideState::Opening { started_at } => {
-                let elapsed = now.checked_duration_since(started_at).unwrap_or(Duration::ZERO);
+                let elapsed = now
+                    .checked_duration_since(started_at)
+                    .unwrap_or(Duration::ZERO);
                 (elapsed.as_secs_f64() / self.slide_duration.as_secs_f64()).min(1.0)
             }
             SlideState::Closing { started_at } => {
-                let elapsed = now.checked_duration_since(started_at).unwrap_or(Duration::ZERO);
+                let elapsed = now
+                    .checked_duration_since(started_at)
+                    .unwrap_or(Duration::ZERO);
                 let progress = (elapsed.as_secs_f64() / self.slide_duration.as_secs_f64()).min(1.0);
                 1.0 - progress
             }
@@ -303,13 +321,19 @@ mod tests {
         // Advance 25% through the animation
         let quarter = start + c.slide_duration() / 4;
         let frac_before = c.overlay_fraction(quarter);
-        assert!((frac_before - 0.25).abs() < 0.01, "expected ~0.25, got {frac_before}");
+        assert!(
+            (frac_before - 0.25).abs() < 0.01,
+            "expected ~0.25, got {frac_before}"
+        );
 
         c.toggle(quarter); // Opening -> Closing (preserving position)
         assert!(matches!(c.slide, SlideState::Closing { .. }));
 
         let frac_after = c.overlay_fraction(quarter);
-        assert!((frac_after - 0.25).abs() < 0.01, "expected ~0.25 after reversal, got {frac_after}");
+        assert!(
+            (frac_after - 0.25).abs() < 0.01,
+            "expected ~0.25 after reversal, got {frac_after}"
+        );
     }
 
     #[test]
@@ -322,13 +346,19 @@ mod tests {
         // Advance 25% through closing (fraction should be 0.75)
         let quarter = start + c.slide_duration() / 4;
         let frac_before = c.overlay_fraction(quarter);
-        assert!((frac_before - 0.75).abs() < 0.01, "expected ~0.75, got {frac_before}");
+        assert!(
+            (frac_before - 0.75).abs() < 0.01,
+            "expected ~0.75, got {frac_before}"
+        );
 
         c.toggle(quarter); // Closing -> Opening (preserving position)
         assert!(matches!(c.slide, SlideState::Opening { .. }));
 
         let frac_after = c.overlay_fraction(quarter);
-        assert!((frac_after - 0.75).abs() < 0.01, "expected ~0.75 after reversal, got {frac_after}");
+        assert!(
+            (frac_after - 0.75).abs() < 0.01,
+            "expected ~0.75 after reversal, got {frac_after}"
+        );
     }
 
     #[test]

--- a/crates/spud-core/src/event.rs
+++ b/crates/spud-core/src/event.rs
@@ -30,7 +30,11 @@ pub enum Event {
     /// A module has been moved to the background.
     ModuleDeactivated { id: String },
     /// A telemetry data point emitted by a module or subsystem.
-    Telemetry { source: String, key: String, value: TelemetryValue },
+    Telemetry {
+        source: String,
+        key: String,
+        value: TelemetryValue,
+    },
     /// An application-defined event for extension points.
     Custom { tag: String, payload: String },
 }

--- a/crates/spud-core/src/fps.rs
+++ b/crates/spud-core/src/fps.rs
@@ -41,7 +41,11 @@ impl TickCounter {
         }
         let now = self.timestamps.back().copied().unwrap();
         let window_start = now - self.window;
-        let count = self.timestamps.iter().filter(|&&t| t >= window_start).count();
+        let count = self
+            .timestamps
+            .iter()
+            .filter(|&&t| t >= window_start)
+            .count();
         count as f64 / self.window.as_secs_f64()
     }
 
@@ -99,6 +103,10 @@ mod tests {
             counter.tick(base + Duration::from_millis(1000 + i * 300));
         }
 
-        assert!(counter.timestamps.len() <= 5, "timestamps: {}", counter.timestamps.len());
+        assert!(
+            counter.timestamps.len() <= 5,
+            "timestamps: {}",
+            counter.timestamps.len()
+        );
     }
 }

--- a/crates/spud-core/src/logging.rs
+++ b/crates/spud-core/src/logging.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
-use tracing_subscriber::{EnvFilter, Layer, layer::SubscriberExt, util::SubscriberInitExt};
 use tracing_appender::rolling;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 
 /// Log severity level (mirrors tracing levels for UI use).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -21,8 +21,8 @@ impl fmt::Display for LogLevel {
         match self {
             LogLevel::Trace => write!(f, "TRACE"),
             LogLevel::Debug => write!(f, "DEBUG"),
-            LogLevel::Info  => write!(f, "INFO"),
-            LogLevel::Warn  => write!(f, "WARN"),
+            LogLevel::Info => write!(f, "INFO"),
+            LogLevel::Warn => write!(f, "WARN"),
             LogLevel::Error => write!(f, "ERROR"),
         }
     }
@@ -80,8 +80,8 @@ const LOG_RETENTION_DAYS: u64 = 7;
 /// the daily rolling appender) to avoid accidentally removing unrelated files
 /// if the log directory is shared.
 fn cleanup_old_logs(log_path: &std::path::Path, max_age_days: u64) {
-    let cutoff = std::time::SystemTime::now()
-        - std::time::Duration::from_secs(max_age_days * 86400);
+    let cutoff =
+        std::time::SystemTime::now() - std::time::Duration::from_secs(max_age_days * 86400);
     if let Ok(entries) = std::fs::read_dir(log_path) {
         for entry in entries.flatten() {
             let name = entry.file_name();
@@ -115,8 +115,8 @@ impl<S: tracing::Subscriber> Layer<S> for ConsoleLayer {
         let level = match *event.metadata().level() {
             tracing::Level::TRACE => LogLevel::Trace,
             tracing::Level::DEBUG => LogLevel::Debug,
-            tracing::Level::INFO  => LogLevel::Info,
-            tracing::Level::WARN  => LogLevel::Warn,
+            tracing::Level::INFO => LogLevel::Info,
+            tracing::Level::WARN => LogLevel::Warn,
             tracing::Level::ERROR => LogLevel::Error,
         };
 
@@ -129,7 +129,11 @@ impl<S: tracing::Subscriber> Layer<S> for ConsoleLayer {
         event.record(&mut visitor);
         let message = visitor.finish();
 
-        let entry = LogEntry { level, target, message };
+        let entry = LogEntry {
+            level,
+            target,
+            message,
+        };
 
         if let Ok(mut buf) = self.buffer.lock() {
             if buf.len() >= self.max_lines {
@@ -188,7 +192,10 @@ pub fn init() -> LogBuffer {
 
     let log_path = log_dir();
     if let Err(e) = std::fs::create_dir_all(&log_path) {
-        eprintln!("warning: failed to create log directory {:?}: {}", log_path, e);
+        eprintln!(
+            "warning: failed to create log directory {:?}: {}",
+            log_path, e
+        );
     }
 
     cleanup_old_logs(&log_path, LOG_RETENTION_DAYS);

--- a/crates/spud-core/src/registry.rs
+++ b/crates/spud-core/src/registry.rs
@@ -210,17 +210,29 @@ mod tests {
 
     impl FakeModule {
         fn new(id: &'static str, title: &'static str) -> Self {
-            Self { id, title, events: Arc::new(Mutex::new(Vec::new())) }
+            Self {
+                id,
+                title,
+                events: Arc::new(Mutex::new(Vec::new())),
+            }
         }
 
         fn with_log(id: &'static str, title: &'static str, log: Arc<Mutex<Vec<String>>>) -> Self {
-            Self { id, title, events: log }
+            Self {
+                id,
+                title,
+                events: log,
+            }
         }
     }
 
     impl Module for FakeModule {
-        fn id(&self) -> &'static str { self.id }
-        fn title(&self) -> &'static str { self.title }
+        fn id(&self) -> &'static str {
+            self.id
+        }
+        fn title(&self) -> &'static str {
+            self.title
+        }
         fn handle_event(&mut self, ev: &Event) {
             let tag = match ev {
                 Event::Tick { .. } => "tick",
@@ -231,15 +243,21 @@ mod tests {
                 Event::Quit => "quit",
                 _ => "other",
             };
-            self.events.lock().unwrap().push(format!("{}:{}", self.id, tag));
+            self.events
+                .lock()
+                .unwrap()
+                .push(format!("{}:{}", self.id, tag));
         }
-        fn as_any(&self) -> &dyn std::any::Any { self }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
     }
 
     #[test]
     fn register_adds_module() {
         let mut reg = ModuleRegistry::new();
-        reg.register(Box::new(FakeModule::new("a", "Alpha"))).unwrap();
+        reg.register(Box::new(FakeModule::new("a", "Alpha")))
+            .unwrap();
         assert_eq!(reg.len(), 1);
         assert_eq!(reg.list(), vec![("a", "Alpha")]);
     }
@@ -247,7 +265,8 @@ mod tests {
     #[test]
     fn duplicate_id_returns_error() {
         let mut reg = ModuleRegistry::new();
-        reg.register(Box::new(FakeModule::new("a", "Alpha"))).unwrap();
+        reg.register(Box::new(FakeModule::new("a", "Alpha")))
+            .unwrap();
         let err = reg.register(Box::new(FakeModule::new("a", "Alpha2")));
         assert!(err.is_err());
         assert!(err.unwrap_err().to_string().contains("duplicate module id"));
@@ -256,8 +275,10 @@ mod tests {
     #[test]
     fn activate_by_id() {
         let mut reg = ModuleRegistry::new();
-        reg.register(Box::new(FakeModule::new("a", "Alpha"))).unwrap();
-        reg.register(Box::new(FakeModule::new("b", "Beta"))).unwrap();
+        reg.register(Box::new(FakeModule::new("a", "Alpha")))
+            .unwrap();
+        reg.register(Box::new(FakeModule::new("b", "Beta")))
+            .unwrap();
         reg.activate("b").unwrap();
         assert_eq!(reg.active().unwrap().id(), "b");
     }
@@ -265,7 +286,8 @@ mod tests {
     #[test]
     fn activate_invalid_id_returns_error() {
         let mut reg = ModuleRegistry::new();
-        reg.register(Box::new(FakeModule::new("a", "Alpha"))).unwrap();
+        reg.register(Box::new(FakeModule::new("a", "Alpha")))
+            .unwrap();
         let err = reg.activate("nope");
         assert!(err.is_err());
         assert!(err.unwrap_err().to_string().contains("unknown module id"));
@@ -274,8 +296,10 @@ mod tests {
     #[test]
     fn activate_emits_lifecycle_events() {
         let mut reg = ModuleRegistry::new();
-        reg.register(Box::new(FakeModule::new("a", "Alpha"))).unwrap();
-        reg.register(Box::new(FakeModule::new("b", "Beta"))).unwrap();
+        reg.register(Box::new(FakeModule::new("a", "Alpha")))
+            .unwrap();
+        reg.register(Box::new(FakeModule::new("b", "Beta")))
+            .unwrap();
         let events = reg.activate("b").unwrap();
         assert_eq!(events.len(), 2);
         assert!(matches!(&events[0], Event::ModuleDeactivated { id } if id == "a"));
@@ -285,7 +309,8 @@ mod tests {
     #[test]
     fn first_register_auto_activates() {
         let mut reg = ModuleRegistry::new();
-        reg.register(Box::new(FakeModule::new("a", "Alpha"))).unwrap();
+        reg.register(Box::new(FakeModule::new("a", "Alpha")))
+            .unwrap();
         assert_eq!(reg.active().unwrap().id(), "a");
     }
 
@@ -299,9 +324,12 @@ mod tests {
     #[test]
     fn cycle_next_wraps() {
         let mut reg = ModuleRegistry::new();
-        reg.register(Box::new(FakeModule::new("a", "Alpha"))).unwrap();
-        reg.register(Box::new(FakeModule::new("b", "Beta"))).unwrap();
-        reg.register(Box::new(FakeModule::new("c", "Gamma"))).unwrap();
+        reg.register(Box::new(FakeModule::new("a", "Alpha")))
+            .unwrap();
+        reg.register(Box::new(FakeModule::new("b", "Beta")))
+            .unwrap();
+        reg.register(Box::new(FakeModule::new("c", "Gamma")))
+            .unwrap();
 
         assert_eq!(reg.active_id(), Some("a"));
         reg.cycle_next();
@@ -315,8 +343,10 @@ mod tests {
     #[test]
     fn cycle_next_emits_lifecycle() {
         let mut reg = ModuleRegistry::new();
-        reg.register(Box::new(FakeModule::new("a", "Alpha"))).unwrap();
-        reg.register(Box::new(FakeModule::new("b", "Beta"))).unwrap();
+        reg.register(Box::new(FakeModule::new("a", "Alpha")))
+            .unwrap();
+        reg.register(Box::new(FakeModule::new("b", "Beta")))
+            .unwrap();
         let events = reg.cycle_next();
         assert_eq!(events.len(), 2);
         assert!(matches!(&events[0], Event::ModuleDeactivated { id } if id == "a"));
@@ -326,9 +356,12 @@ mod tests {
     #[test]
     fn cycle_prev_wraps() {
         let mut reg = ModuleRegistry::new();
-        reg.register(Box::new(FakeModule::new("a", "Alpha"))).unwrap();
-        reg.register(Box::new(FakeModule::new("b", "Beta"))).unwrap();
-        reg.register(Box::new(FakeModule::new("c", "Gamma"))).unwrap();
+        reg.register(Box::new(FakeModule::new("a", "Alpha")))
+            .unwrap();
+        reg.register(Box::new(FakeModule::new("b", "Beta")))
+            .unwrap();
+        reg.register(Box::new(FakeModule::new("c", "Gamma")))
+            .unwrap();
 
         assert_eq!(reg.active_id(), Some("a"));
         reg.cycle_prev();
@@ -340,8 +373,10 @@ mod tests {
     #[test]
     fn list_returns_id_title_pairs() {
         let mut reg = ModuleRegistry::new();
-        reg.register(Box::new(FakeModule::new("x", "X-Ray"))).unwrap();
-        reg.register(Box::new(FakeModule::new("y", "Yankee"))).unwrap();
+        reg.register(Box::new(FakeModule::new("x", "X-Ray")))
+            .unwrap();
+        reg.register(Box::new(FakeModule::new("y", "Yankee")))
+            .unwrap();
         assert_eq!(reg.list(), vec![("x", "X-Ray"), ("y", "Yankee")]);
     }
 
@@ -356,7 +391,8 @@ mod tests {
     #[test]
     fn get_and_get_mut_by_id() {
         let mut reg = ModuleRegistry::new();
-        reg.register(Box::new(FakeModule::new("a", "Alpha"))).unwrap();
+        reg.register(Box::new(FakeModule::new("a", "Alpha")))
+            .unwrap();
         assert_eq!(reg.get("a").unwrap().title(), "Alpha");
         assert!(reg.get("z").is_none());
         assert!(reg.get_mut("a").is_some());
@@ -368,10 +404,14 @@ mod tests {
         let log_a = Arc::new(Mutex::new(Vec::new()));
         let log_b = Arc::new(Mutex::new(Vec::new()));
         let mut reg = ModuleRegistry::new();
-        reg.register(Box::new(FakeModule::with_log("a", "Alpha", log_a.clone()))).unwrap();
-        reg.register(Box::new(FakeModule::with_log("b", "Beta", log_b.clone()))).unwrap();
+        reg.register(Box::new(FakeModule::with_log("a", "Alpha", log_a.clone())))
+            .unwrap();
+        reg.register(Box::new(FakeModule::with_log("b", "Beta", log_b.clone())))
+            .unwrap();
 
-        reg.broadcast(&Event::Tick { now: Instant::now() });
+        reg.broadcast(&Event::Tick {
+            now: Instant::now(),
+        });
         assert_eq!(log_a.lock().unwrap().as_slice(), &["a:tick"]);
         assert_eq!(log_b.lock().unwrap().as_slice(), &["b:tick"]);
     }
@@ -381,8 +421,10 @@ mod tests {
         let log_a = Arc::new(Mutex::new(Vec::new()));
         let log_b = Arc::new(Mutex::new(Vec::new()));
         let mut reg = ModuleRegistry::new();
-        reg.register(Box::new(FakeModule::with_log("a", "Alpha", log_a.clone()))).unwrap();
-        reg.register(Box::new(FakeModule::with_log("b", "Beta", log_b.clone()))).unwrap();
+        reg.register(Box::new(FakeModule::with_log("a", "Alpha", log_a.clone())))
+            .unwrap();
+        reg.register(Box::new(FakeModule::with_log("b", "Beta", log_b.clone())))
+            .unwrap();
 
         let key = crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::Char('x'),
@@ -398,8 +440,10 @@ mod tests {
         let log_a = Arc::new(Mutex::new(Vec::new()));
         let log_b = Arc::new(Mutex::new(Vec::new()));
         let mut reg = ModuleRegistry::new();
-        reg.register(Box::new(FakeModule::with_log("a", "Alpha", log_a.clone()))).unwrap();
-        reg.register(Box::new(FakeModule::with_log("b", "Beta", log_b.clone()))).unwrap();
+        reg.register(Box::new(FakeModule::with_log("a", "Alpha", log_a.clone())))
+            .unwrap();
+        reg.register(Box::new(FakeModule::with_log("b", "Beta", log_b.clone())))
+            .unwrap();
 
         reg.broadcast(&Event::ModuleActivated { id: "b".into() });
         assert!(log_a.lock().unwrap().is_empty());

--- a/crates/spud-mod-hello/Cargo.toml
+++ b/crates/spud-mod-hello/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ratatui = "0.28"
+ratatui = { workspace = true }
 spud-core = { path = "../spud-core" }
 spud-ui = { path = "../spud-ui" }

--- a/crates/spud-mod-hello/src/lib.rs
+++ b/crates/spud-mod-hello/src/lib.rs
@@ -1,13 +1,16 @@
 use std::any::Any;
 
 use ratatui::{
-    Frame,
     layout::{Alignment, Rect},
-    widgets::{Block, Borders, Paragraph},
     text::Line,
+    widgets::{Block, Borders, Paragraph},
+    Frame,
 };
 
-use spud_core::{event::Event, module::{HudContribution, Module}};
+use spud_core::{
+    event::Event,
+    module::{HudContribution, Module},
+};
 use spud_ui::renderer::HeroRenderer;
 
 /// A minimal welcome-screen module.
@@ -18,34 +21,38 @@ use spud_ui::renderer::HeroRenderer;
 pub struct HelloModule;
 
 impl Default for HelloModule {
-    fn default() -> Self { Self }
+    fn default() -> Self {
+        Self
+    }
 }
 
 impl HelloModule {
     /// Create a new `HelloModule`.
-    pub fn new() -> Self { Self }
+    pub fn new() -> Self {
+        Self
+    }
 }
 
 impl Module for HelloModule {
-    fn id(&self) -> &'static str { "hello" }
-    fn title(&self) -> &'static str { "Hello" }
+    fn id(&self) -> &'static str {
+        "hello"
+    }
+    fn title(&self) -> &'static str {
+        "Hello"
+    }
 
     fn handle_event(&mut self, _ev: &Event) {}
 
     fn hud(&self) -> HudContribution {
         HudContribution {
-            left_lines: vec![
-                "Tab: next module".into(),
-                "q: quit".into(),
-            ],
-            right_lines: vec![
-                "HMR: (planned)".into(),
-                "IMG: (planned)".into(),
-            ],
+            left_lines: vec!["Tab: next module".into(), "q: quit".into()],
+            right_lines: vec!["HMR: (planned)".into(), "IMG: (planned)".into()],
         }
     }
 
-    fn as_any(&self) -> &dyn Any { self }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl HeroRenderer for HelloModule {

--- a/crates/spud-mod-stats/Cargo.toml
+++ b/crates/spud-mod-stats/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ratatui = "0.28"
+ratatui = { workspace = true }
 spud-core = { path = "../spud-core" }
 spud-ui = { path = "../spud-ui" }

--- a/crates/spud-mod-stats/src/lib.rs
+++ b/crates/spud-mod-stats/src/lib.rs
@@ -1,13 +1,16 @@
 use std::any::Any;
 
 use ratatui::{
-    Frame,
     layout::Rect,
-    widgets::{Block, Borders, Paragraph},
     text::Line,
+    widgets::{Block, Borders, Paragraph},
+    Frame,
 };
 
-use spud_core::{event::Event, module::{HudContribution, Module}};
+use spud_core::{
+    event::Event,
+    module::{HudContribution, Module},
+};
 use spud_ui::renderer::HeroRenderer;
 
 /// System-stats module (stub).
@@ -17,17 +20,25 @@ use spud_ui::renderer::HeroRenderer;
 pub struct StatsModule;
 
 impl Default for StatsModule {
-    fn default() -> Self { Self }
+    fn default() -> Self {
+        Self
+    }
 }
 
 impl StatsModule {
     /// Create a new `StatsModule`.
-    pub fn new() -> Self { Self }
+    pub fn new() -> Self {
+        Self
+    }
 }
 
 impl Module for StatsModule {
-    fn id(&self) -> &'static str { "stats" }
-    fn title(&self) -> &'static str { "Stats (stub)" }
+    fn id(&self) -> &'static str {
+        "stats"
+    }
+    fn title(&self) -> &'static str {
+        "Stats (stub)"
+    }
 
     fn handle_event(&mut self, _ev: &Event) {}
 
@@ -38,7 +49,9 @@ impl Module for StatsModule {
         }
     }
 
-    fn as_any(&self) -> &dyn Any { self }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl HeroRenderer for StatsModule {

--- a/crates/spud-ui/Cargo.toml
+++ b/crates/spud-ui/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ratatui = "0.28"
+ratatui = { workspace = true }
 spud-core = { path = "../spud-core" }

--- a/crates/spud-ui/src/console.rs
+++ b/crates/spud-ui/src/console.rs
@@ -1,9 +1,9 @@
 use ratatui::{
-    Frame,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
+    Frame,
 };
 
 use spud_core::console::Console;
@@ -15,7 +15,14 @@ use spud_core::logging::LogLevel;
 /// 1. **Title bar** — shows `CONSOLE` label, current TPS, and close hint.
 /// 2. **Log area** — colour-coded log entries with scroll support.
 /// 3. **Input line** — single-line command input with cursor.
-pub fn render_console(f: &mut Frame, area: Rect, console: &Console, tps: f64, fraction: f64, show_cursor: bool) {
+pub fn render_console(
+    f: &mut Frame,
+    area: Rect,
+    console: &Console,
+    tps: f64,
+    fraction: f64,
+    show_cursor: bool,
+) {
     let max_height = area.height / 2;
     let mut overlay_height = ((max_height as f64) * fraction).round() as u16;
     // Need at least 3 rows for title + log + input; clamp during animation,
@@ -40,15 +47,21 @@ pub fn render_console(f: &mut Frame, area: Rect, console: &Console, tps: f64, fr
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),    // title bar
-            Constraint::Min(1),      // log area
-            Constraint::Length(1),    // input line
+            Constraint::Length(1), // title bar
+            Constraint::Min(1),    // log area
+            Constraint::Length(1), // input line
         ])
         .split(overlay);
 
     // Title bar with TPS
     let title = Line::from(vec![
-        Span::styled(" CONSOLE ", Style::default().fg(Color::Black).bg(Color::Yellow).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            " CONSOLE ",
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::raw(format!("  TPS: {:.1}  ", tps)),
         Span::styled("~ to close", Style::default().fg(Color::DarkGray)),
     ]);
@@ -77,15 +90,17 @@ pub fn render_console(f: &mut Frame, area: Rect, console: &Console, tps: f64, fr
         .map(|entry| {
             let level_color = match entry.level {
                 LogLevel::Error => Color::Red,
-                LogLevel::Warn  => Color::Yellow,
-                LogLevel::Info  => Color::Green,
+                LogLevel::Warn => Color::Yellow,
+                LogLevel::Info => Color::Green,
                 LogLevel::Debug => Color::Cyan,
                 LogLevel::Trace => Color::DarkGray,
             };
             Line::from(vec![
                 Span::styled(
                     format!(" {:5} ", entry.level),
-                    Style::default().fg(level_color).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(level_color)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(
                     format!("[{}] ", entry.target),
@@ -101,13 +116,20 @@ pub fn render_console(f: &mut Frame, area: Rect, console: &Console, tps: f64, fr
         .style(Style::default().bg(Color::Black));
 
     f.render_widget(
-        Paragraph::new(lines).block(log_block).wrap(Wrap { trim: false }),
+        Paragraph::new(lines)
+            .block(log_block)
+            .wrap(Wrap { trim: false }),
         chunks[1],
     );
 
     // Input line
     let input_line = Line::from(vec![
-        Span::styled("> ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            "> ",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::raw(&console.input_buffer),
     ]);
     f.render_widget(
@@ -117,9 +139,6 @@ pub fn render_console(f: &mut Frame, area: Rect, console: &Console, tps: f64, fr
 
     // Position cursor in the input field only when fully open
     if show_cursor {
-        f.set_cursor_position((
-            chunks[2].x + 2 + console.cursor_pos as u16,
-            chunks[2].y,
-        ));
+        f.set_cursor_position((chunks[2].x + 2 + console.cursor_pos as u16, chunks[2].y));
     }
 }

--- a/crates/spud-ui/src/renderer.rs
+++ b/crates/spud-ui/src/renderer.rs
@@ -1,4 +1,4 @@
-use ratatui::{Frame, layout::Rect};
+use ratatui::{layout::Rect, Frame};
 
 /// Trait for modules that render content in the hero (main) area.
 ///

--- a/crates/spud-ui/src/shell.rs
+++ b/crates/spud-ui/src/shell.rs
@@ -1,9 +1,9 @@
 use ratatui::{
-    Frame,
     layout::Rect,
-    widgets::{Block, Borders, Paragraph},
     style::Style,
     text::{Line, Text},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
 };
 
 use crate::layout::DoomRects;
@@ -44,17 +44,32 @@ pub fn render_shell(
 
     hero(f, rects.hero);
 
-    f.render_widget(Block::default().borders(Borders::ALL).title("HUD"), rects.hud);
+    f.render_widget(
+        Block::default().borders(Borders::ALL).title("HUD"),
+        rects.hud,
+    );
 
-    let left_text = Text::from(view.hud_left.into_iter().map(Line::from).collect::<Vec<_>>());
-    let left = Paragraph::new(left_text).block(Block::default().borders(Borders::ALL).title("LEFT"));
+    let left_text = Text::from(
+        view.hud_left
+            .into_iter()
+            .map(Line::from)
+            .collect::<Vec<_>>(),
+    );
+    let left =
+        Paragraph::new(left_text).block(Block::default().borders(Borders::ALL).title("LEFT"));
     f.render_widget(left, rects.hud_left);
 
     let face = Paragraph::new(Line::from("[ FACE ]"))
         .block(Block::default().borders(Borders::ALL).title("AGENT"));
     f.render_widget(face, rects.hud_face);
 
-    let right_text = Text::from(view.hud_right.into_iter().map(Line::from).collect::<Vec<_>>());
-    let right = Paragraph::new(right_text).block(Block::default().borders(Borders::ALL).title("RIGHT"));
+    let right_text = Text::from(
+        view.hud_right
+            .into_iter()
+            .map(Line::from)
+            .collect::<Vec<_>>(),
+    );
+    let right =
+        Paragraph::new(right_text).block(Block::default().borders(Borders::ALL).title("RIGHT"));
     f.render_widget(right, rects.hud_right);
 }


### PR DESCRIPTION
## Summary

- Upgrades ratatui from `0.28` to `0.30` across all crates that depend on it
- Resolves `lru` transitive dependency from `0.12.5` (vulnerable) to `0.16.3` (patched)
- Fixes Dependabot alert [GHSA-rhfx-m35p-ff5j](https://github.com/advisories/GHSA-rhfx-m35p-ff5j): `IterMut` violates Stacked Borrows

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` — 75 tests pass
- [x] `cargo clippy --workspace` — clean
- [ ] Visual check: `cargo run -p spud-app` renders correctly

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated UI rendering library to version 0.30 across all application components, incorporating latest improvements and bug fixes from the upstream library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->