### PR TITLE
Smooth console animation: separate render rate from tick rate

### DIFF
--- a/crates/spud-app/src/main.rs
+++ b/crates/spud-app/src/main.rs
@@ -243,7 +243,7 @@ fn run(terminal: &mut Terminal<CrosstermBackend<Stdout>>, log_buffer: LogBuffer)
         })?;
 
         // ── Poll → Publish ──
-        if event::poll(Duration::from_millis(16))? {
+        if event::poll(poll_timeout)? {
             match event::read()? {
                 CEvent::Key(key) => {
                     // Tilde always toggles the console


### PR DESCRIPTION
## Summary

- Split `tick_rate` into `poll_timeout` (1ms) and `tick_interval` (100ms) so the render loop runs uncapped while `Tick` events stay at ~10/s
- The console slide animation already interpolates by wall-clock time — this gives it many more visible frames across its 250ms duration
- Single-file, 4-line change in `crates/spud-app/src/main.rs`

## Test plan

- [x] `cargo build -p spud-app` compiles
- [x] `cargo test --workspace` — 75 tests pass
- [x] `cargo clippy --workspace` — clean
- [ ] `cargo run -p spud-app` — visual: console animation is smooth, TPS shows ~10

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)