### PR TITLE
Document Phase 6 roadmap + agentic design (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ Current status:
   - `spud-mod-hello`
   - `spud-mod-stats` (real telemetry via `sysinfo`)
 - Phase 4 plugin runtime work is tracked in the GitHub roadmap.
+- Phase 6 agentic module planning is tracked in [#52](https://github.com/tjhanley/spud/issues/52).
+
+### Roadmap Snapshot
+- `v0.4 — Plugin Runtime`:
+  - [#13](https://github.com/tjhanley/spud/issues/13) tracking
+- `v0.5 — Themes & Polish`:
+  - [#14](https://github.com/tjhanley/spud/issues/14) tracking
+- `v0.6 — Agentic Workflows`:
+  - [#52](https://github.com/tjhanley/spud/issues/52) tracking
+  - [`docs/phase-6-agentic-module.md`](docs/phase-6-agentic-module.md) design
+  - [#47](https://github.com/tjhanley/spud/issues/47) runtime contract
+  - [#50](https://github.com/tjhanley/spud/issues/50) orchestration runtime
+  - [#51](https://github.com/tjhanley/spud/issues/51) tool bridge + permissions
+  - [#46](https://github.com/tjhanley/spud/issues/46) provider adapters
+  - [#49](https://github.com/tjhanley/spud/issues/49) UI surfaces
+  - [#48](https://github.com/tjhanley/spud/issues/48) safety + observability
 
 ### Run
 ```bash

--- a/docs/phase-6-agentic-module.md
+++ b/docs/phase-6-agentic-module.md
@@ -1,0 +1,76 @@
+# Phase 6: Agentic Module Design
+
+This document captures the target architecture for `v0.6 — Agentic Workflows`.
+
+Tracking issue: [#52](https://github.com/tjhanley/spud/issues/52)
+
+## Goals
+- Add a first-party agentic workflow to SPUD without hardcoding a model vendor.
+- Keep provider/model selection fully configuration-driven.
+- Let agents call SPUD capabilities through a permissioned module bridge.
+- Expose clear agent state and output in existing TUI layout.
+
+## Non-Goals
+- No provider lock-in in `spud-core`.
+- No async runtime migration in this phase.
+- No UI redesign that discards current HUD shell structure.
+
+## UX Layout Mapping
+- Bottom-left tray: persistent prompt composer.
+- Right panel: spawned agents with lifecycle state, elapsed time, and mood badge.
+- Hero pane: output stream for currently selected agent.
+
+## Runtime Architecture
+- `spud-core`:
+  - agent lifecycle/state machine types
+  - orchestration queue (enqueue, spawn, cancel, retry)
+  - event contracts for state/output/mood
+- `spud-config`:
+  - provider/model config schema
+  - limits and permission allowlists
+- `spud-ui`:
+  - prompt composer widget
+  - agent list/state panel
+  - hero output stream view
+- Provider adapters:
+  - implemented behind shared traits
+  - local + cloud paths selectable by config
+
+## Agent Lifecycle
+- `queued`
+- `planning`
+- `running`
+- `waiting_input`
+- `completed`
+- `failed`
+- `cancelled`
+
+State transitions are explicit and validated by tests.
+
+## Tool/Module Bridge
+- Agents can invoke allowlisted module actions only.
+- Unauthorized actions return structured errors.
+- Mood hints from agents are normalized by host and emitted as UI-consumable mood events.
+
+## Config Shape (Proposed)
+```toml
+[agent]
+provider = "ollama"
+model = "qwen2.5-coder:14b"
+temperature = 0.2
+max_tokens = 2048
+max_concurrent_agents = 2
+request_timeout_ms = 30000
+max_tool_calls_per_task = 12
+
+[agent.permissions]
+module_actions = ["stats.snapshot", "hello.greet", "core.command.run"]
+```
+
+## Delivery Slices
+- #47: runtime contract (provider-agnostic)
+- #50: orchestration runtime
+- #51: tool bridge + module permissions
+- #46: config-driven provider adapters
+- #49: UI surfaces (tray/panel/hero)
+- #48: safety limits + observability


### PR DESCRIPTION
## Summary
- add a Phase 6 design doc for agentic workflows in docs/phase-6-agentic-module.md
- update README with a roadmap snapshot and direct links to Phase 6 tracking issues
- align docs with the new v0.6 milestone and issue structure

## Validation
- docs-only change (no code paths modified)

Closes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 6 reference and a roadmap snapshot covering v0.4, v0.5, and v0.6.
  * Expanded run instructions with a concrete command to start the app.
  * Introduced comprehensive Phase 6: Agentic Module Design docs detailing architecture, agent lifecycle states and transitions, provider-agnostic configuration options, tool/module bridge behavior, UX considerations, performance/limits, and delivery milestones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->